### PR TITLE
Feat: Implement RAG for ToolSelectorAgent

### DIFF
--- a/prompts/tool_selector.txt
+++ b/prompts/tool_selector.txt
@@ -13,12 +13,11 @@ Your task is to review provided information about material, defect/observation, 
     `Recommended Sensor Names: [Sensor1 Name], [Sensor2 Name]`
     (If only one method or sensor is recommended, list only one.)
 
-**Input Context will include:**
-*   Material
-*   Defect/Observation
-*   Environment
-*   KG Recommended NDT Methods (with potential attributes like description, category, cost)
-*   KG Recommended Sensors
+**Input Context will include sections for:**
+*   Primary Material, Defect/Observation, Environment.
+*   KG Recommended NDT Methods (initial list).
+*   KG Recommended Sensors (initial list).
+*   **Detailed Information from Knowledge Graph:** This section provides specific attributes (like descriptions, categories, costs) for the entities involved. **Use this detailed information extensively when forming your justifications.**
 
 **Example Output Structure (Illustrative - follow instructions above for lists):**
 


### PR DESCRIPTION
- Added `get_entities_details_for_rag` to KGInterface to fetch detailed descriptions and attributes for materials and NDT methods.
- Modified ToolSelectorAgent's `run()` and `run_structured()` methods to:
    - Call `get_entities_details_for_rag` to retrieve context.
    - Prepend this retrieved context to the information sent to the LLM.
- Updated `prompts/tool_selector.txt` to instruct the LLM to utilize this richer, retrieved context when formulating its justifications for NDT method and sensor recommendations. This aims to make the agent's justifications more detailed and grounded
  in knowledge graph facts.